### PR TITLE
feat: add rawResponse option to MockMethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,22 @@ export default [
       },
     },
   },
+  {
+    url: '/api/text',
+    method: 'post',
+    rawResponse: async (req, res) => {
+      let reqbody = '';
+      await new Promise((resolve) => {
+        req.on('data', (chunk) => {
+          reqbody += chunk;
+        });
+        req.on('end', () => resolve(undefined));
+      });
+      res.setHeader('Content-Type', 'text/plain');
+      res.statusCode = 200;
+      res.end(`hello, ${reqbody}`);
+    },
+  },
 ] as MockMethod[];
 ```
 
@@ -232,8 +248,10 @@ export default [
   timeout?: number;
   // default: 200
   statusCode?:number;
-  // response data
-  response: ((opt: { [key: string]: string; body: Record<string,any>; query:  Record<string,any>, headers: Record<string, any>; }) => any) | any;
+  // response data (JSON)
+  response?: ((opt: { [key: string]: string; body: Record<string,any>; query:  Record<string,any>, headers: Record<string, any>; }) => any) | any;
+  // response (non-JSON)
+  rawResponse?: (req: IncomingMessage, res: ServerResponse) => void;
 }
 
 ```

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -195,6 +195,22 @@ export default [
       },
     },
   },
+  {
+    url: '/api/text',
+    method: 'post',
+    rawResponse: async (req, res) => {
+      let reqbody = '';
+      await new Promise((resolve) => {
+        req.on('data', (chunk) => {
+          reqbody += chunk;
+        });
+        req.on('end', () => resolve(undefined));
+      });
+      res.setHeader('Content-Type', 'text/plain');
+      res.statusCode = 200;
+      res.end(`hello, ${reqbody}`);
+    },
+  },
 ] as MockMethod[];
 ```
 
@@ -210,8 +226,10 @@ export default [
   timeout?: number;
   // 状态吗
   statusCode?:number;
-  // 响应数据
-  response: ((opt: { [key: string]: string; body: Record<string,any>; query:  Record<string,any>, headers: Record<string, any>; }) => any) | any;
+  // 响应数据（JSON）
+  response?: ((opt: { [key: string]: string; body: Record<string,any>; query:  Record<string,any>, headers: Record<string, any>; }) => any) | any;
+  // 响应（非JSON）
+  rawResponse?: (req: IncomingMessage, res: ServerResponse) => void;
 }
 
 ```

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { IncomingMessage, ServerResponse } from 'node:http';
+
 export interface ViteMockOptions {
   mockPath?: string;
   configPath?: string;
@@ -20,7 +22,8 @@ export declare interface MockMethod {
   method?: MethodType;
   timeout?: number;
   statusCode?: number;
-  response: ((opt: { body: Recordable; query: Recordable; headers: Recordable }) => any) | any;
+  response?: ((opt: { body: Recordable; query: Recordable; headers: Recordable }) => any) | any;
+  rawResponse?: (req: IncomingMessage, res: ServerResponse) => void;
 }
 
 export interface NodeModuleWithCompile extends NodeModule {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ export function is(val: unknown, type: string) {
 
 // eslint-disable-next-line
 export function isFunction<T = Function>(val: unknown): val is T {
-  return is(val, 'Function');
+  return is(val, 'Function') || is(val, 'AsyncFunction');
 }
 
 export function isArray(val: any): val is Array<any> {


### PR DESCRIPTION
With `rawResponse` we can parse arbitrary requests and return arbitrary responses, instead of being limited to application/json. An example has been added to README.

Fixes #16.