### PR TITLE
增强 response 函数：允许定制返回状态码和返回头，支持返回非JSON序列化类型

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,36 @@ export default [
       },
     },
   },
+  // Custom status code and response
+  {
+    url: '/api/query',
+    method: 'get',
+    response: ({ query, res }) => {
+      // res.setHeader('X-Hello', 'World')
+      if (query.name === 'vite') {
+        res.statusCode = 200
+        return { message: 'OK' }
+      } else {
+        res.statusCode = 404
+        return { message: 'Not Found' }
+      }
+    },
+  },
+  {
+    url: '/api/plaintext',
+    method: 'get',
+    response: () => {
+      return '200 OK'
+    },
+  },
+  // 204 No Content
+  {
+    url: '/api/204',
+    method: 'get',
+    response: () => {
+      return
+    },
+  },
   {
     url: '/api/text',
     method: 'post',

--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ export default [
     },
   },
   {
+    url: '/api/get',
+    method: 'get',
+    response: async ({ query }) => {
+      return {
+        code: 0,
+        data: {
+          name: 'vben',
+        },
+      }
+    },
+  },
+  {
     url: '/api/post',
     method: 'post',
     timeout: 2000,

--- a/packages/vite-plugin-mock/src/createMockServer.ts
+++ b/packages/vite-plugin-mock/src/createMockServer.ts
@@ -94,7 +94,7 @@ export async function requestMiddleware(opt: ViteMockOptions) {
         }
         res.statusCode = statusCode || 200
         const mockResponse = isFunction(response)
-          ? response.bind(self)({ url: req.url as any, body, query, headers: req.headers })
+          ? response.bind(self)({ url: req.url as any, body, query, headers: req.headers, req, res })
           : response
         res.end(JSON.stringify(Mock.mock(mockResponse)))
       }

--- a/packages/vite-plugin-mock/src/types.ts
+++ b/packages/vite-plugin-mock/src/types.ts
@@ -28,7 +28,7 @@ export declare interface MockMethod {
   response?:
     | ((
         this: RespThisType,
-        opt: { url: Recordable; body: Recordable; query: Recordable; headers: Recordable },
+        opt: { url: Recordable; body: Recordable; query: Recordable; headers: Recordable, req: IncomingMessage, res: ServerResponse },
       ) => any)
     | any
   rawResponse?: (this: RespThisType, req: IncomingMessage, res: ServerResponse) => void


### PR DESCRIPTION
本PR解决的问题;
- vite-plugin-mock 的 response 函数绑定了 middleware 的 this，可以支持访问 req, resp。但这种方法不够直观，并且在箭头函数下会失效。本PR直接将 req, resp 作为参数传入到 response 函数，可以让开发更加方便
- 在 response 函数内设置了 statusCode 的情况下，不再覆盖 statusCode
- 支持 response 返回 Buffer | UInt8Array类型，并在未指定 Content-Type 的情况下，自动添加 application/octet-stream
- 在 response 函数返回 undefined 时，响应 204 No Content
- 在 response 函数返回 string 类型时，不做 JSON encode

相关Issues:
https://github.com/vbenjs/vite-plugin-mock/issues/132
https://github.com/vbenjs/vite-plugin-mock/issues/137